### PR TITLE
Nicotine+ 2.1.0 (appdata release fix)

### DIFF
--- a/org.nicotine_plus.Nicotine.yaml
+++ b/org.nicotine_plus.Nicotine.yaml
@@ -77,8 +77,7 @@ modules:
     buildsystem: simple
     sources:
       - url: https://github.com/nicotine-plus/nicotine-plus.git
-        tag: 2.1.0
-        commit: f996c7ef6ff02e6575d784c597d9866283881005
+        commit: 0444bbaa2efdb48049c4dcb60c7f20d7c773e311
         type: git
     build-commands:
       - python3 setup.py install --prefix="${FLATPAK_DEST}"


### PR DESCRIPTION
Temporary until we tag a new release in the future.